### PR TITLE
Add blog page with dedicated navigation tab

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0CBEZ4JQKP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-0CBEZ4JQKP');
+  </script>
+  <meta name="yandex-verification" content="a2b0dfa3a10b5338" />
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
+  <title>Junlin Wang&mdash; Blog</title>
+  <link rel="stylesheet" href="master.css" />
+
+  <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:300,400,700" rel="stylesheet">
+
+
+  <script type="text/javascript">
+    var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+  </script>
+</head>
+<nav class="navbar" style="background-color: #ffffff;padding:20px 0px 0px 70px;">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <!-- <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#myNavbar"> -->
+      <!-- <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span> -->
+      <!-- </button> -->
+      <h1 class="navbar-brand" href="#">Junlin Wang</h1>
+    </div>
+    <div>
+      <div class="collapse navbar-collapse" id="myNavbar">
+        <ul class="nav navbar-nav" style="float: right;">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="blog.html">Blog</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<body>
+  <main role="main" class="container">
+
+    <div class="wrapper">
+
+      <div class="posts-wrapper" style="clear:both" id="blog">
+        <h3 style="margin-bottom:0.75em;">Blog Posts</h3>
+        <ul class="blogs">
+          <li><a href="http://ucinlp.github.io/facade" target="_blank" rel="noopener noreferrer">Gradient-based Analysis of NLP Models is Manipulable</a> - 2020</li>
+          <li><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer">AllenNLP Interpret: A Framework for Explaining Predictions of NLP Models</a> - 2019</li>
+        </ul>
+      </div>
+    </div>
+  </main>
+
+</body>
+
+</html>
+

--- a/index.html
+++ b/index.html
@@ -46,16 +46,16 @@
     </div>
     <div>
       <div class="collapse navbar-collapse" id="myNavbar">
-        <ul class="nav navbar-nav" style="float: right;">
-          <li><a href="#home">Home</a></li>
-          <li><a href="#pub">Publications</a></li>
-          <li><a href="#proj">Projects</a></li>
-          <li><a href="#blog">Blog</a></li>
-        </ul>
+          <ul class="nav navbar-nav" style="float: right;">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="#pub">Publications</a></li>
+            <li><a href="#proj">Projects</a></li>
+            <li><a href="blog.html">Blog</a></li>
+          </ul>
+        </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
 
 <body>
   <main role="main" class="container">
@@ -307,13 +307,6 @@
       <h3 style="margin-bottom:0.75em;">Projects</h3>
       <a href="pages/index.html"><span>Link to some of my for fun projects</span></a>
 
-    </div>
-    <div class="posts-wrapper" style="clear:both" id="blog">
-      <h3 style="margin-bottom:0.75em;">Blog Posts</h3>
-      <ul class="blogs">
-        <li><a href="http://ucinlp.github.io/facade" target="_blank" rel="noopener noreferrer">Gradient-based Analysis of NLP Models is Manipulable</a> - 2020</li>
-        <li><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer">AllenNLP Interpret: A Framework for Explaining Predictions of NLP Models</a> - 2019</li>
-      </ul>
     </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- add standalone `blog.html` page containing existing blog links
- update site navigation so Home and Blog tabs link to their respective pages
- remove inline blog section from the home page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898fb446b48832b8c1a12f65f63b9cf